### PR TITLE
Ensure shortest path is used in vtkQuaternion::Slerp()

### DIFF
--- a/Common/Math/vtkQuaternion.txx
+++ b/Common/Math/vtkQuaternion.txx
@@ -496,6 +496,13 @@ template<typename T> vtkQuaternion<T> vtkQuaternion<T>
     t2 = sin(t*theta)/sin(theta);
     }
 
+  // Enforces shortest path
+
+  if (dot < 0.)
+    {
+    t2 *= -1.;
+    }
+
   return (*this)*t1 + q1*t2;
 }
 


### PR DESCRIPTION
From Wikipedia:
However, because the covering is double (q and −q map to the same
rotation), the rotation path may turn either the "short way" (less
than 180°) or the "long way" (more than 180°). Long paths can be
prevented by negating one end if the dot product, cos Ω, is negative,
thus ensuring that −90° ≤ Ω ≤ 90°.
