### PR TITLE
Fix X3D exporter when launched multiple times

### DIFF
--- a/IO/Export/vtkX3DExporterFIWriterHelper.h
+++ b/IO/Export/vtkX3DExporterFIWriterHelper.h
@@ -193,7 +193,7 @@ public:
     if (firstTime)
     {
       writer->PutBits("1001000000001010");
-      firstTime = false;
+      //firstTime = false;
     }
     else
     {


### PR DESCRIPTION
firstTime static boolean doesn't seem to have any purpose whatsoever.